### PR TITLE
Refactored codebase to follow core guidelines more closely and have a better ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,182 +1,168 @@
-# PL-JIT-Compiler-Project
+# PL JIT Compiler
 
-Small C++23 interpreter project built around a handwritten AST, a `cpp-peglib` parser, and a direct tree-walk runtime.
+Small programming language project in C++23. It runs source files in the custom language by parsing them into an AST,
+optionally printing the parsed form with `--debug`, and then executing them.
 
-## Current Language
+Current implementation:
 
-- Multiple top-level functions
-- Required zero-argument `fn main()` CLI entry point
-- Function parameters and arguments
-- Function calls in expression and statement position
-- `return;` and `return expr;`
-- Implicit `nothing` return at function end
-- `print(...)` with optional expression and no automatic newline
-- `println(...)` with optional expression and a trailing newline
-- `let` declarations and assignment to existing variables
-- Integer, boolean, and `nothing` values
-- Arithmetic `+ - * /` on integers
-- Relational `< <= > >=` on integers
-- Equality `== !=`
-- Logical `&& ||` with short-circuit behavior
-- Parenthesized expressions
-- Nested blocks and lexical block scoping with shadowing
-- `if / else if / else`
-- `while`
-- `for let i = init; condition; i = update { ... }`
-- `break` and `continue`
-- `//` line comments
+- a parser for a custom language
+- a handwritten AST
+- a tree-walk runtime
+- a golden-test-based language implementation project
 
-Not implemented:
+It is not a VM or JIT yet (this is the future plan)
 
-- Strings, floats, arrays, tables, closures
-- Unary operators or modulo
-- General expression statements beyond function-call statements
-- Imports/modules or type annotations
+## ReadMe Contents
 
-## Semantics
+- [Build And Run](#build-and-run)
+- [Scripts And Tests](#scripts-and-tests)
+- [Project Layout](#project-layout)
+- [Language](#language)
+- [Semantics](#semantics)
 
-- Runtime values are `int64_t`, `bool`, and `nothing`
-- `false`, `nothing`, and integer `0` are falsy
-- Nonzero integers and `true` are truthy
-- `main` must not take parameters
-- `return;` returns `nothing`
-- Falling off the end of a function returns `nothing`
-- Function arguments are evaluated left-to-right in the caller
-- Each function call creates a fresh call frame and one top-level function scope
-- Parameters and top-level function locals live in that same function scope
-- Equality on mismatched runtime types is `false`
-- Logical operators return booleans, not original operands
-- `break` and `continue` outside loops are runtime errors
-- `print` renders integers as decimal, booleans as `true` / `false`, and `nothing` as `nothing`
-- `println` behaves like `print` and then writes a newline
-- `print()` writes nothing; `println()` writes just a newline
+## Build And Run
 
-## Grammar
+Requirements:
 
-```peg
-Program                    <- Function+
-Function                   <- ~KeywordFn Identifier '(' Parameters ')' Block
-Parameters                 <- ParameterList / EmptyParameters
-ParameterList              <- Identifier (',' Identifier)*
-EmptyParameters            <- ''
-Block                      <- '{' Statement* '}'
-Statement                  <- Block / PrintlnStatement / PrintStatement / LetStatement / AssignmentStatement / IfStatement / WhileStatement / ContinueStatement / BreakStatement / ReturnStatement / ForStatement / FunctionCallStatement
-PrintStatement             <- ~KeywordPrint '(' Expression? ')' ';'
-PrintlnStatement           <- ~KeywordPrintln '(' Expression? ')' ';'
-LetStatement               <- ~KeywordLet Identifier '=' Expression ';'
-AssignmentStatement        <- Identifier '=' Expression ';'
-IfStatement                <- ~KeywordIf Expression Block (~KeywordElse ~KeywordIf Expression Block)* (~KeywordElse Block)?
-WhileStatement             <- ~KeywordWhile Expression Block
-ForStatement               <- ~KeywordFor LetStatement Expression ';' ForUpdate Block
-ForUpdate                  <- Identifier '=' Expression
-ContinueStatement          <- ~KeywordContinue ';'
-BreakStatement             <- ~KeywordBreak ';'
-ReturnStatement            <- ~KeywordReturn Expression? ';'
-FunctionCallStatement      <- FunctionCallExpression ';'
-Expression                 <- InfixExpression(Atom, InfixOperator)
-Atom                       <- Integer / Bool / Nothing / FunctionCallExpression / IdentifierExpression / '(' Expression ')'
-FunctionCallExpression     <- Identifier '(' Arguments ')'
-Arguments                  <- ArgumentList / EmptyArguments
-ArgumentList               <- Expression (',' Expression)*
-EmptyArguments             <- ''
-IdentifierExpression       <- Identifier
-InfixOperator              <- < '&&' / '||' / '==' / '!=' / '<=' / '>=' / '<' / '>' / [-+/*] >
-Bool                       <- ~KeywordTrue / ~KeywordFalse
-Nothing                    <- ~KeywordNothing
-Integer                    <- < '-'? [0-9]+ >
-Identifier                 <- !Keyword IdentifierToken
-IdentifierToken            <- < [a-zA-Z_][a-zA-Z0-9_]* >
-Keyword                    <- KeywordFn / KeywordLet / KeywordPrint / KeywordPrintln / KeywordIf / KeywordElse / KeywordTrue / KeywordFalse / KeywordNothing / KeywordWhile / KeywordFor / KeywordContinue / KeywordBreak / KeywordReturn
-```
+- CMake `3.20+`
+- C++23 compiler
 
-## Architecture
-
-Pipeline:
-
-1. `src/main.cpp` reads the source file
-2. `src/parser/parser.cpp` parses it using `src/parser/language_grammar.h`
-3. The parser builds the AST from `src/ast/ast.h`
-4. `src/ast/ast_printer.cpp` prints normalized source for `--debug`
-5. `src/tree_interpreter/tree_interpreter.cpp` executes the AST directly
-
-Key implementation notes:
-
-- The parser uses `cpp-peglib` semantic values stored as `std::any`
-- Recursive AST expression children use `std::shared_ptr` to stay copyable for parser actions
-- `PrintStatement` represents both `print` and `println` with a newline flag in the AST
-- Function calls evaluate arguments in the caller, then bind parameter values in the callee
-- The top-level function scope is created by function execution, not by ordinary block execution
-- Statement and block execution propagate `ExecutionResult` values carrying normal flow, return, break, or continue
-
-## Source Layout
-
-- `src/main.cpp`: CLI entry point
-- `src/parser/`: grammar and parser actions
-- `src/ast/`: AST definitions and debug printer
-- `src/tree_interpreter/`: runtime model and interpreter
-- `src/common/overloaded.h`: `std::visit` helper
-- `tests/pass`: passing golden tests
-- `tests/fail`: failing golden tests
-- `scripts/`: test and debug helpers
-
-## Build
+From the project root:
 
 ```sh
 make build
+make clean
 ```
 
-Toolchain:
-
-- CMake `3.20+`
-- C++23
-- Clang/GCC warnings: `-Wall -Wextra -Wpedantic`
-
-## Run
+Run a source file manually:
 
 ```sh
 ./build/interpreter SOURCE
+```
+
+Run and print the parsed AST first:
+
+```sh
 ./build/interpreter --debug SOURCE
 ```
 
-`--debug` prints the parsed AST before execution.
+## Scripts And Tests
 
-## Test
+Run one passing or failing fixture:
 
 ```sh
 ./scripts/run_single_test.sh tests/pass/<name>.ee
 ./scripts/run_single_test.sh tests/fail/<name>.ee
-./scripts/run_passing_tests.sh
-./scripts/run_failing_tests.sh
-./scripts/run_all_tests.sh
-./scripts/debug_test.sh tests/pass/<name>.ee
 ```
 
-The suite is golden-file based:
+Run all passing tests:
 
-- passing tests use `.ee` + `.out`
-- failing tests use `.ee` + `.err`
-- stdout/stderr text is exact-match checked
-- `./scripts/run_all_tests.sh` runs the full passing and failing fixture suite
+```sh
+./scripts/run_passing_tests.sh
+```
 
-## Current Limits
+Run all failing tests:
 
-- Parse and runtime failures are surfaced as `std::runtime_error` messages printed to `stderr`
-- `main` parameters are rejected at runtime rather than by a separate semantic-analysis pass
-- Duplicate parameter names are currently rejected at runtime when parameters are bound into scope
-- `break` / `continue` placement is validated at runtime, not in a separate semantic-analysis pass
-- Only top-level functions exist; there are no nested functions or closures
-- Only `int64_t`, `bool`, and `nothing` exist as runtime values
-- Arithmetic and relational operators currently require integer operands
-- There is no VM, GC, or JIT yet
-- Integer arithmetic does not currently check overflow, so signed overflow is undefined behavior instead of a reported runtime error
+```sh
+./scripts/run_failing_tests.sh
+```
 
-## Future Direction
+Run the full suite:
 
-- Add expression statements beyond function-call statements
-- Add more builtins beyond `print` / `println`
-- Add strings and floats
-- Add unary operators and modulo
-- Add arrays and tables
-- Add first-class functions and closures
-- Improve diagnostics and semantic validation
-- Move toward a VM / GC / JIT path after interpreter semantics stabilize
+```sh
+./scripts/run_all_tests.sh
+```
+
+The tests are golden-file based:
+
+- passing tests compare exact stdout against `.out`
+- failing tests compare exact stderr against `.err`
+- wording and punctuation of diagnostics matter
+
+Scripts:
+
+- `scripts/run_single_test.sh`: run one fixture and compare output
+- `scripts/run_passing_tests.sh`: run all passing fixtures
+- `scripts/run_failing_tests.sh`: run all failing fixtures
+- `scripts/run_all_tests.sh`: run the full suite
+- `scripts/debug_test.sh`: run one fixture with `--debug`
+
+## Project Layout
+
+### Top level
+
+- `CMakeLists.txt`: build definition
+- `Makefile`: small wrapper around common CMake commands
+- `README.md`: project overview and usage
+- `third_party/peglib.h`: vendored `cpp-peglib`
+
+### Source
+
+- `src/main.cpp`: CLI entry point, `--debug` handling, top-level error reporting
+- `src/parser/language_grammar.h`: PEG grammar string
+- `src/parser/parser.h`: parser interface
+- `src/parser/parser.cpp`: parser construction and semantic actions that build the AST
+- `src/ast/ast.h`: AST node definitions
+- `src/ast/ast_printer.h`: AST printer interface
+- `src/ast/ast_printer.cpp`: source-like AST pretty printer used by `--debug`
+- `src/tree_interpreter/tree_interpreter.h`: interpreter entry point
+- `src/tree_interpreter/tree_interpreter.cpp`: runtime state, scope handling, expression evaluation, and statement
+  execution
+- `src/common/overloaded.h`: helper for `std::visit`
+
+### Tests
+
+- `tests/pass`: programs expected to succeed
+- `tests/fail`: programs expected to fail
+
+For fixtures:
+
+- `.ee`: source file
+- `.out`: expected stdout for passing tests
+- `.err`: expected stderr for failing tests
+
+## Language
+
+Current language support:
+
+- multiple top-level functions
+- required zero-argument `fn main()` entry point
+- function parameters and function calls
+- `print(...)` and `println(...)`
+- `let` declarations with required initializers
+- assignment to existing variables
+- `return;` and `return expr;`
+- integer, boolean, and `nothing` literals
+- identifier expressions
+- arithmetic `+`, `-`, `*`, `/`
+- relational `<`, `<=`, `>`, `>=`
+- equality `==`, `!=`
+- logical `&&`, `||`
+- parenthesized expressions
+- nested blocks
+- `if / else if / else`
+- `while`
+- `for let i = init; condition; i = update { ... }`
+- `break`
+- `continue`
+- `//` line comments
+
+## Semantics
+
+- runtime values are `int64_t`, `bool`, and `nothing`
+- `false`, `nothing`, and integer `0` are falsy
+- nonzero integers and `true` are truthy
+- functions implicitly return `nothing` if no `return` executes
+- `main` must exist and must not take parameters
+- function arguments are evaluated left-to-right in the caller
+- each function call creates a fresh call frame
+- parameters and top-level function locals live in the same function scope
+- blocks use lexical scoping with shadowing
+- equality on mismatched runtime types is `false`
+- logical operators return booleans, not original operands
+- `print` does not add a newline
+- `println` prints a trailing newline
+- `print()` writes nothing
+- `println()` writes only a newline
+- `break` and `continue` outside loops are runtime errors
+- parse and runtime failures are reported as `std::runtime_error` messages on stderr

--- a/src/ast/ast_printer.cpp
+++ b/src/ast/ast_printer.cpp
@@ -1,4 +1,5 @@
 #include <format>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -15,24 +16,28 @@ namespace ast_walk {
 
   std::string ToString(const pl_ast::ExpressionVariant& expression_variant);
 
-  std::string ToString(const std::vector<pl_ast::Identifier>& identifiers) {
+  std::string ToString(std::span<const pl_ast::Identifier> identifiers) {
     std::string joined_identifiers;
-    for (size_t current_identifier = 0; current_identifier < identifiers.size(); ++current_identifier) {
-      if (current_identifier != 0) {
+    bool first_identifier = true;
+    for (const auto& identifier : identifiers) {
+      if (!first_identifier) {
         joined_identifiers += ", ";
       }
-      joined_identifiers += identifiers[current_identifier].name_;
+      joined_identifiers += identifier.name_;
+      first_identifier = false;
     }
     return joined_identifiers;
   }
 
-  std::string ToString(const std::vector<pl_ast::CopyableExpressionPointer>& arguments) {
+  std::string ToString(std::span<const pl_ast::CopyableExpressionPointer> arguments) {
     std::string joined_arguments;
-    for (size_t current_argument = 0; current_argument < arguments.size(); ++current_argument) {
-      if (current_argument != 0) {
+    bool first_argument = true;
+    for (const auto& argument : arguments) {
+      if (!first_argument) {
         joined_arguments += ", ";
       }
-      joined_arguments += ToString(*arguments[current_argument]);
+      joined_arguments += ToString(*argument);
+      first_argument = false;
     }
     return joined_arguments;
   }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -18,8 +19,13 @@ namespace parser {
 
   // Parsing library requires copyable types
   template <std::copy_constructible T>
-  T CastSemanticValueTo(const peg::SemanticValues& semantic_values, const size_t index) {
-    return std::any_cast<T>(semantic_values[index]);
+  T CastSemanticValueTo(const std::any& value) {
+    return std::any_cast<T>(value);
+  }
+
+  template <typename T>
+  T ExtractStatementNode(const std::any& value) {
+    return std::get<T>(CastSemanticValueTo<pl_ast::StatementVariant>(value));
   }
 
   template <typename ExpressionNode, typename Operator>
@@ -30,7 +36,7 @@ namespace parser {
                      .left_operand_ = std::make_shared<pl_ast::ExpressionVariant>(std::move(left_operand)),
                      .operator_ = operator_value,
                      .right_operand_ = std::make_shared<pl_ast::ExpressionVariant>(std::move(right_operand)),
-      }
+                     }
     };
   }
 
@@ -38,7 +44,7 @@ namespace parser {
     pl_ast::PrintStatement print_statement;
     print_statement.new_line_ = new_line;
     if (!semantic_values.empty()) {
-      print_statement.print_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
+      print_statement.print_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
     }
     return print_statement;
   }
@@ -57,10 +63,10 @@ namespace parser {
     parser["Function"] = [](const peg::SemanticValues& semantic_values) {
       pl_ast::Function function;
 
-      function.identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values, 0);
-      function.parameters_ = CastSemanticValueTo<std::vector<pl_ast::Identifier>>(semantic_values, 1);
+      function.identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values[0]);
+      function.parameters_ = CastSemanticValueTo<std::vector<pl_ast::Identifier>>(semantic_values[1]);
 
-      function.function_block_ = std::get<pl_ast::BlockPointer>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 2));
+      function.function_block_ = ExtractStatementNode<pl_ast::BlockPointer>(semantic_values[2]);
 
       return function;
     };
@@ -69,8 +75,8 @@ namespace parser {
       std::vector<pl_ast::Identifier> parameters;
       parameters.reserve(semantic_values.size());
 
-      for (size_t parameter_index = 0; parameter_index < semantic_values.size(); ++parameter_index) {
-        parameters.push_back(CastSemanticValueTo<pl_ast::Identifier>(semantic_values, parameter_index));
+      for (const auto& semantic_value : semantic_values) {
+        parameters.push_back(CastSemanticValueTo<pl_ast::Identifier>(semantic_value));
       }
 
       return parameters;
@@ -89,8 +95,8 @@ namespace parser {
     parser["LetStatement"] = [](const peg::SemanticValues& semantic_values) {
       return pl_ast::StatementVariant{
         pl_ast::LetStatement{
-                             .identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values, 0),
-                             .initializer_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 1),
+                             .identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values[0]),
+                             .initializer_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[1]),
                              }
       };
     };
@@ -98,34 +104,33 @@ namespace parser {
     parser["AssignmentStatement"] = [](const peg::SemanticValues& semantic_values) {
       return pl_ast::StatementVariant{
         pl_ast::AssignmentStatement{
-                                    .identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values, 0),
-                                    .assigned_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 1),
+                                    .identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values[0]),
+                                    .assigned_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[1]),
                                     }
       };
     };
 
     parser["IfStatement"] = [](const peg::SemanticValues& semantic_values) {
       // First two semantic values are if, last one is else if it's present, everything in the middle is else ifs
-      auto if_condition = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
-      auto if_block = std::get<pl_ast::BlockPointer>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 1));
+      auto if_condition = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
+      auto if_block = ExtractStatementNode<pl_ast::BlockPointer>(semantic_values[1]);
 
       pl_ast::ElseIfConditionBlockPairs else_if_branches;
       // Semantic values are: if condition, if block, zero or more else-if condition/block pairs,
       // and an optional trailing else block.
-      const size_t number_of_else_if_branches = (semantic_values.size() - 2) / 2;
-      for (size_t current_branch = 1; current_branch <= number_of_else_if_branches; ++current_branch) {
+      const bool has_else_block = semantic_values.size() % 2 == 1;
+      const size_t else_if_end = has_else_block ? semantic_values.size() - 1 : semantic_values.size();
+      for (size_t branch_index = 2; branch_index < else_if_end; branch_index += 2) {
         else_if_branches.emplace_back(
-          CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, current_branch * 2),
-          std::get<pl_ast::BlockPointer>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, current_branch * 2 + 1))
+          CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[branch_index]),
+          ExtractStatementNode<pl_ast::BlockPointer>(semantic_values[branch_index + 1])
         );
       }
 
       std::optional<pl_ast::BlockPointer> else_block;
-      if (semantic_values.size() % 2) {
-        else_block =
-          std::get<pl_ast::BlockPointer>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, semantic_values.size() - 1));
+      if (has_else_block) {
+        else_block = ExtractStatementNode<pl_ast::BlockPointer>(semantic_values.back());
       }
-
       return pl_ast::StatementVariant{
         pl_ast::IfStatement{
                             .if_condition_ = std::move(if_condition),
@@ -137,8 +142,8 @@ namespace parser {
     };
 
     parser["WhileStatement"] = [](const peg::SemanticValues& semantic_values) {
-      auto while_condition = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
-      auto while_block = std::get<pl_ast::BlockPointer>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 1));
+      auto while_condition = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
+      auto while_block = ExtractStatementNode<pl_ast::BlockPointer>(semantic_values[1]);
 
       return pl_ast::StatementVariant{
         pl_ast::WhileStatement{.while_condition_ = std::move(while_condition), .while_block_ = std::move(while_block)}
@@ -147,10 +152,10 @@ namespace parser {
 
     parser["ForStatement"] = [](const peg::SemanticValues& semantic_values) {
       // Statements are all held as statement variant, so we cant any cast straight to let statement / assignment statement
-      auto initializer = std::get<pl_ast::LetStatement>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 0));
-      auto condition = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 1);
-      auto update = std::get<pl_ast::AssignmentStatement>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 2));
-      auto for_block = std::get<pl_ast::BlockPointer>(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 3));
+      auto initializer = ExtractStatementNode<pl_ast::LetStatement>(semantic_values[0]);
+      auto condition = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[1]);
+      auto update = ExtractStatementNode<pl_ast::AssignmentStatement>(semantic_values[2]);
+      auto for_block = ExtractStatementNode<pl_ast::BlockPointer>(semantic_values[3]);
 
       return pl_ast::StatementVariant{
         pl_ast::ForStatement{
@@ -165,8 +170,8 @@ namespace parser {
     parser["ForUpdate"] = [](const peg::SemanticValues& semantic_values) {
       return pl_ast::StatementVariant{
         pl_ast::AssignmentStatement{
-                                    .identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values, 0),
-                                    .assigned_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 1),
+                                    .identifier_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values[0]),
+                                    .assigned_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[1]),
                                     }
       };
     };
@@ -178,14 +183,14 @@ namespace parser {
     parser["ReturnStatement"] = [](const peg::SemanticValues& semantic_values) {
       pl_ast::ReturnStatement return_statement;
       if (!semantic_values.empty()) {
-        return_statement.return_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
+        return_statement.return_expression_ = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
       }
       return pl_ast::StatementVariant{return_statement};
     };
 
     parser["FunctionCallStatement"] = [](const peg::SemanticValues& semantic_values) {
       return pl_ast::StatementVariant{pl_ast::FunctionCallStatement{
-        .function_call_ = std::get<pl_ast::FunctionCallExpression>(CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0))
+        .function_call_ = std::get<pl_ast::FunctionCallExpression>(CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]))
       }};
     };
 
@@ -201,8 +206,8 @@ namespace parser {
 
     parser["FunctionCallExpression"] = [](const peg::SemanticValues& semantic_values) {
       pl_ast::FunctionCallExpression function_call_expression;
-      function_call_expression.function_name_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values, 0);
-      function_call_expression.arguments_ = CastSemanticValueTo<std::vector<pl_ast::CopyableExpressionPointer>>(semantic_values, 1);
+      function_call_expression.function_name_ = CastSemanticValueTo<pl_ast::Identifier>(semantic_values[0]);
+      function_call_expression.arguments_ = CastSemanticValueTo<std::vector<pl_ast::CopyableExpressionPointer>>(semantic_values[1]);
 
       return pl_ast::ExpressionVariant{std::move(function_call_expression)};
     };
@@ -211,10 +216,8 @@ namespace parser {
       std::vector<pl_ast::CopyableExpressionPointer> arguments;
       arguments.reserve(semantic_values.size());
 
-      for (size_t argument_index = 0; argument_index < semantic_values.size(); ++argument_index) {
-        arguments.push_back(
-          std::make_shared<pl_ast::ExpressionVariant>(CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, argument_index))
-        );
+      for (const auto& semantic_value : semantic_values) {
+        arguments.push_back(std::make_shared<pl_ast::ExpressionVariant>(CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_value)));
       }
 
       return arguments;
@@ -223,7 +226,7 @@ namespace parser {
     parser["EmptyArguments"] = [](const peg::SemanticValues&) { return std::vector<pl_ast::CopyableExpressionPointer>{}; };
 
     parser["IdentifierExpression"] = [](const peg::SemanticValues& semantic_values) {
-      return pl_ast::ExpressionVariant{pl_ast::IdentifierExpression{CastSemanticValueTo<pl_ast::Identifier>(semantic_values, 0)}};
+      return pl_ast::ExpressionVariant{pl_ast::IdentifierExpression{CastSemanticValueTo<pl_ast::Identifier>(semantic_values[0])}};
     };
 
     parser["InfixOperator"] = [](const peg::SemanticValues& semantic_values) {
@@ -257,22 +260,22 @@ namespace parser {
     };
 
     parser["Atom"] = [](const peg::SemanticValues& semantic_values) {
-      return CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
+      return CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
     };
 
     parser["Expression"] = [](const peg::SemanticValues& semantic_values) {
-      return CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
+      return CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
     };
 
     parser["InfixExpression"] = [](const peg::SemanticValues& semantic_values) {
-      auto left_operand = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 0);
+      auto left_operand = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[0]);
 
       if (semantic_values.size() == 1) {
         return left_operand;
       }
 
-      const auto infix_operator = CastSemanticValueTo<InfixOperator>(semantic_values, 1);
-      auto right_operand = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values, 2);
+      const auto infix_operator = CastSemanticValueTo<InfixOperator>(semantic_values[1]);
+      auto right_operand = CastSemanticValueTo<pl_ast::ExpressionVariant>(semantic_values[2]);
 
       return std::visit(
         template_helpers::Overloaded{
@@ -294,15 +297,15 @@ namespace parser {
     };
 
     parser["Statement"] = [](const peg::SemanticValues& semantic_values) {
-      return CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, 0);
+      return CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values[0]);
     };
 
     parser["Block"] = [](const peg::SemanticValues& semantic_values) {
       std::vector<pl_ast::StatementVariant> statement_variants;
       statement_variants.reserve(semantic_values.size());
 
-      for (size_t semantic_value_index = 0; semantic_value_index < semantic_values.size(); ++semantic_value_index) {
-        statement_variants.push_back(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_values, semantic_value_index));
+      for (const auto& semantic_value : semantic_values) {
+        statement_variants.push_back(CastSemanticValueTo<pl_ast::StatementVariant>(semantic_value));
       }
 
       return pl_ast::StatementVariant{std::make_shared<pl_ast::Block>(pl_ast::Block{.statements_ = std::move(statement_variants)})};
@@ -310,10 +313,9 @@ namespace parser {
 
     parser["Program"] = [](const peg::SemanticValues& semantic_values) {
       pl_ast::Program program;
-      const size_t number_of_functions = semantic_values.size();
-      program.functions_.reserve(number_of_functions);
-      for (size_t current_function = 0; current_function < number_of_functions; ++current_function) {
-        program.functions_.push_back(CastSemanticValueTo<pl_ast::Function>(semantic_values, current_function));
+      program.functions_.reserve(semantic_values.size());
+      for (const auto& semantic_value : semantic_values) {
+        program.functions_.push_back(CastSemanticValueTo<pl_ast::Function>(semantic_value));
       }
       return program;
     };
@@ -324,7 +326,7 @@ namespace parser {
     return parser;
   }
 
-  pl_ast::Program ParseFileContentsIntoAST(const std::string& file_contents) {
+  pl_ast::Program ParseFileContentsIntoAST(std::string_view file_contents) {
     auto parser = MakeParser();
 
     size_t error_line = 0;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -1,12 +1,12 @@
 #ifndef parser_H
 #define parser_H
 
-#include <string>
+#include <string_view>
 
 #include "../ast/ast.h"
 
 namespace parser {
-  pl_ast::Program ParseFileContentsIntoAST(const std::string& file_contents);
+  pl_ast::Program ParseFileContentsIntoAST(std::string_view file_contents);
 }
 
 #endif // parser_H

--- a/src/tree_interpreter/tree_interpreter.cpp
+++ b/src/tree_interpreter/tree_interpreter.cpp
@@ -1,6 +1,9 @@
+#include <algorithm>
 #include <iostream>
+#include <iterator>
 #include <optional>
 #include <ranges>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -240,15 +243,15 @@ namespace tree_interpreter {
       return {*left_integer, *right_integer};
     }
 
-    Value ExecuteFunction(const pl_ast::Function& function, const std::vector<Value>& arguments) {
+    Value ExecuteFunction(const pl_ast::Function& function, std::span<const Value> arguments) {
       if (arguments.size() != function.parameters_.size()) {
         throw std::runtime_error("ExecuteFunction: argument count doesn't match parameter count");
       }
 
       RuntimeState::CallFrameGuard call_frame_guard(runtime_state_);
       RuntimeState::ScopeGuard function_level_scope(runtime_state_);
-      for (size_t argument_index = 0; argument_index < arguments.size(); ++argument_index) {
-        runtime_state_.DeclareVariable(function.parameters_[argument_index].name_, arguments[argument_index]);
+      for (auto&& [parameter, argument] : std::views::zip(function.parameters_, arguments)) {
+        runtime_state_.DeclareVariable(parameter.name_, argument);
       }
 
       const auto [control_flow, return_value] = ExecuteBlock(function.function_block_, false);
@@ -418,9 +421,11 @@ namespace tree_interpreter {
             // Need to evaluate all the arguments to pass to execute function
             std::vector<Value> evaluated_arguments;
             evaluated_arguments.reserve(function_call_expression.arguments_.size());
-            for (const auto& argument : function_call_expression.arguments_) {
-              evaluated_arguments.push_back(EvaluateExpression(*argument));
-            }
+
+            std::ranges::transform(
+              function_call_expression.arguments_, std::back_inserter(evaluated_arguments),
+              [this](const auto& argument) { return EvaluateExpression(*argument); }
+            );
 
             return ExecuteFunction(
               runtime_state_.LookupFunctionOrThrow(function_call_expression.function_name_.name_), evaluated_arguments


### PR DESCRIPTION
## What Changed?
Incorporated spans, string_views, and std algos like transform. Also updated readme.

## Why Did You Change It?
Wanted to modernize the code base as much as possible.

## How Did You Test It?
Ensured all tests were still passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized the parser, interpreter, and AST printer to use safer interfaces (`std::span`, `std::string_view`) and standard algorithms; rewrote the README with clearer build/run/test docs. No behavior changes; all tests pass.

- **Refactors**
  - Parser: `ParseFileContentsIntoAST` now takes `std::string_view`; added `ExtractStatementNode<T>`; `CastSemanticValueTo<T>` now accepts `const std::any&`; replaced index loops with range-based loops; simplified `if / else if / else` by detecting an else and iterating pairs.
  - AST printer: `ToString` for identifiers/arguments now takes `std::span`; simpler joining.
  - Interpreter: `ExecuteFunction` now takes `std::span<const Value>`; parameter binding via `std::views::zip`; argument evaluation via `std::ranges::transform`.

- **Migration**
  - If you call `parser::ParseFileContentsIntoAST`, pass a `std::string_view` (a `std::string` can be passed as a view if its lifetime outlives the parse).

<sup>Written for commit 878f3b674495191b38cb41472b4658e071b4b55e. Summary will update on new commits. <a href="https://cubic.dev/pr/EmreAErsahin/PL-JIT-Compiler-Project/pull/43?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

