### PR TITLE
Added string support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Current language support:
 - `let` declarations with required initializers
 - assignment to existing variables
 - `return;` and `return expr;`
-- integer, double, boolean, and `nothing` literals
+- integer, double, boolean, string, and `nothing` literals
 - identifier expressions
 - unary `-`, `!`
 - arithmetic `+`, `-`, `*`, `/` on numeric values, with `%` on integers only
@@ -151,9 +151,9 @@ Current language support:
 
 ## Semantics
 
-- runtime values are `int64_t`, `double`, `bool`, and `nothing`
-- `false`, `nothing`, integer `0`, and double `0.0` are falsy
-- nonzero integers, nonzero doubles, and `true` are truthy
+- runtime values are `int64_t`, `double`, `bool`, `string`, and `nothing`
+- `false`, `nothing`, integer `0`, double `0.0`, and empty strings are falsy
+- nonzero integers, nonzero doubles, non-empty strings, and `true` are truthy
 - functions implicitly return `nothing` if no `return` executes
 - `main` must exist and must not take parameters
 - function arguments are evaluated left-to-right in the caller before the function is looked up and called

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -22,6 +22,10 @@ namespace ast {
     bool value_;
   };
 
+  struct StringLiteralExpression {
+    std::string value_;
+  };
+
   struct NothingLiteralExpression {};
 
   // Identifiers name variables, functions, and parameters.
@@ -43,8 +47,9 @@ namespace ast {
   // clang-format on
 
   using ExpressionVariant = std::variant<
-    IntegerLiteralExpression, DoubleLiteralExpression, BoolLiteralExpression, NothingLiteralExpression, IdentifierExpression,
-    ArithmeticExpression, RelationalExpression, EqualityExpression, LogicalExpression, UnaryExpression, FunctionCallExpression>;
+    IntegerLiteralExpression, DoubleLiteralExpression, BoolLiteralExpression, StringLiteralExpression, NothingLiteralExpression,
+    IdentifierExpression, ArithmeticExpression, RelationalExpression, EqualityExpression, LogicalExpression, UnaryExpression,
+    FunctionCallExpression>;
 
   // cpp-peglib stores semantic values as std::any, so recursive AST nodes must be copyable during parsing.
   // The AST still owns these nodes logically; shared_ptr is used for parser compatibility.

--- a/src/ast/ast_printer.cpp
+++ b/src/ast/ast_printer.cpp
@@ -16,7 +16,7 @@ namespace ast_walk {
 
   std::string ToString(const ast::ExpressionVariant& expression_variant);
 
-  std::string ToString(std::span<const ast::Identifier> identifiers) {
+  std::string ToString(const std::span<const ast::Identifier> identifiers) {
     std::string joined_identifiers;
     bool first_identifier = true;
     for (const auto& identifier : identifiers) {
@@ -92,12 +92,28 @@ namespace ast_walk {
     throw std::runtime_error("ToString: unsupported unary operator");
   }
 
+  std::string EscapeStringLiteral(const std::string& string_value) {
+    std::string escaped_string;
+    for (const char character : string_value) {
+      switch (character) {
+        case '\n': escaped_string += "\\n"; break;
+        case '\t': escaped_string += "\\t"; break;
+        case '\\': escaped_string += "\\\\"; break;
+        default: escaped_string += character; break;
+      }
+    }
+    return escaped_string;
+  }
+
   std::string ToString(const ast::ExpressionVariant& expression_variant) {
     return std::visit(
       template_helpers::Overloaded{
         [](const ast::IntegerLiteralExpression& integer_expression) -> std::string { return std::to_string(integer_expression.value_); },
         [](const ast::DoubleLiteralExpression& double_expression) -> std::string { return std::format("{:g}", double_expression.value_); },
         [](const ast::BoolLiteralExpression& bool_expression) -> std::string { return bool_expression.value_ ? "true" : "false"; },
+        [](const ast::StringLiteralExpression& string_expression) -> std::string {
+          return std::format("\"{}\"", EscapeStringLiteral(string_expression.value_));
+        },
         [](const ast::NothingLiteralExpression&) -> std::string { return "nothing"; },
         [](const ast::IdentifierExpression& identifier_expression) -> std::string { return identifier_expression.identifier_.name_; },
         [](const ast::ArithmeticExpression& arithmetic_expression) -> std::string {

--- a/src/parser/language_grammar.h
+++ b/src/parser/language_grammar.h
@@ -33,7 +33,7 @@ namespace parser_grammar {
       Expression                 <- InfixExpression(UnaryExpression, InfixOperator)
       UnaryExpression            <- UnaryOperator UnaryExpression / Atom
       UnaryOperator              <- < '-' / '!' >
-      Atom                       <- Double / Integer / Bool / Nothing / FunctionCallExpression / IdentifierExpression / '(' Expression ')'
+      Atom                       <- Double / Integer / Bool / String / Nothing / FunctionCallExpression / IdentifierExpression / '(' Expression ')'
       FunctionCallExpression     <- Identifier '(' Arguments ')'
       Arguments                  <- ArgumentList / EmptyArguments
       ArgumentList               <- Expression (',' Expression)*
@@ -43,7 +43,8 @@ namespace parser_grammar {
       Bool                       <- ~KeywordTrue / ~KeywordFalse
       Nothing                    <- ~KeywordNothing
       Integer                    <- < [0-9]+ >
-      Double                      <- < [0-9]* '.' [0-9]+ >
+      Double                     <- < [0-9]* '.' [0-9]+ >
+      String                     <- < '"' ('\\' [nt\\] / !('"' / '\\' / EndOfLine) .)* '"' >
       Identifier                 <- !Keyword IdentifierToken
       IdentifierToken            <- < [a-zA-Z_][a-zA-Z0-9_]* >
       Keyword                    <- KeywordFn / KeywordLet / KeywordPrint / KeywordPrintln / KeywordIf / KeywordElse / KeywordTrue / KeywordFalse / KeywordNothing / KeywordWhile / KeywordFor / KeywordContinue / KeywordBreak / KeywordReturn

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -199,6 +199,26 @@ namespace parser {
       return ast::ExpressionVariant{ast::BoolLiteralExpression{semantic_values.choice() == 0}};
     };
 
+    parser["String"] = [](const peg::SemanticValues& semantic_values) {
+      const std::string encoded_string = semantic_values.token_to_string();
+      // Decode escape sequences after skipping the captured start/end quotes.
+      std::string decoded_string;
+      for (size_t index = 1; index < encoded_string.size() - 1; ++index) {
+        if (encoded_string[index] != '\\') {
+          decoded_string += encoded_string[index];
+          continue;
+        }
+        ++index;
+        switch (encoded_string[index]) {
+          case 'n': decoded_string += '\n'; break;
+          case 't': decoded_string += '\t'; break;
+          case '\\': decoded_string += '\\'; break;
+          default: throw std::runtime_error("String: unsupported escape sequence");
+        }
+      }
+      return ast::ExpressionVariant{ast::StringLiteralExpression{std::move(decoded_string)}};
+    };
+
     parser["Nothing"] = [](const peg::SemanticValues&) { return ast::ExpressionVariant{ast::NothingLiteralExpression{}}; };
 
     parser["FunctionCallExpression"] = [](const peg::SemanticValues& semantic_values) {

--- a/src/tree_interpreter/runtime_value.cpp
+++ b/src/tree_interpreter/runtime_value.cpp
@@ -1,6 +1,7 @@
 #include <concepts>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 
 #include "../common/overloaded.h"
 #include "runtime_value.h"
@@ -9,10 +10,9 @@ namespace tree_interpreter {
   bool IsTruthy(const RuntimeValue& value) {
     return std::visit(
       template_helpers::Overloaded{
-        [](const int64_t integer_value) { return integer_value != 0; },
-        [](const double double_value) { return double_value != 0; },
-        [](const bool bool_value) { return bool_value; },
-        [](const NothingValue&) { return false; },
+        [](const int64_t integer_value) { return integer_value != 0; }, [](const double double_value) { return double_value != 0; },
+        [](const bool bool_value) { return bool_value; }, [](const std::string& string_value) { return !string_value.empty(); },
+        [](const NothingValue&) { return false; }
       },
       value
     );
@@ -43,7 +43,7 @@ namespace tree_interpreter {
       case ast::ArithmeticOperator::kModulo: break;
     }
 
-    throw std::runtime_error("ExecuteArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers");
+    throw std::runtime_error("ComputeArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers");
   }
 
   RuntimeValue ExecuteArithmeticOperation(
@@ -72,7 +72,7 @@ namespace tree_interpreter {
           return ComputeArithmeticOperation(left_double, arithmetic_operator, right_integer);
         },
         [](const auto&, const auto&) -> RuntimeValue {
-          throw std::runtime_error("ExecuteArithmeticOperation: unsupported arithmetic operator");
+          throw std::runtime_error("ExecuteArithmeticOperation: unsupported operand types for arithmetic operator (bool, nothing, string)");
         },
       },
       left_value, right_value
@@ -90,7 +90,7 @@ namespace tree_interpreter {
       case ast::RelationalOperator::kGreaterThanOrEqual: return left_operand >= right_operand;
     }
 
-    throw std::runtime_error("ExecuteRelationalOperation: unsupported relational operator");
+    throw std::runtime_error("ComputeRelationalOperation: unsupported relational operator");
   }
 
   RuntimeValue ExecuteRelationalOperation(
@@ -111,7 +111,7 @@ namespace tree_interpreter {
           return ComputeRelationalOperation(left_double, relational_operator, right_integer);
         },
         [](const auto&, const auto&) -> RuntimeValue {
-          throw std::runtime_error("ExecuteRelationalOperation: unsupported relational operator");
+          throw std::runtime_error("ExecuteRelationalOperation: unsupported operands for relational operator (bool, nothing, string)");
         },
       },
       left_value, right_value
@@ -128,6 +128,7 @@ namespace tree_interpreter {
         [](const double left_double, const int64_t right_integer) { return left_double == right_integer; },
         [](const bool left_bool, const bool right_bool) { return left_bool == right_bool; },
         [](const NothingValue&, const NothingValue&) { return true; },
+        [](const std::string& left_string, const std::string& right_string) { return left_string == right_string; },
         [](const auto&, const auto&) { return false; },
       },
       left_value, right_value
@@ -173,6 +174,7 @@ namespace tree_interpreter {
         [](const int64_t integer_value) { std::cout << integer_value; },
         [](const double double_value) { std::cout << double_value; },
         [](const bool bool_value) { std::cout << (bool_value ? "true" : "false"); },
+        [](const std::string& string_value) { std::cout << string_value; },
         [](const NothingValue&) { std::cout << "nothing"; },
       },
       value

--- a/src/tree_interpreter/runtime_value.h
+++ b/src/tree_interpreter/runtime_value.h
@@ -2,6 +2,7 @@
 #define runtime_value_H
 
 #include <cstdint>
+#include <string>
 #include <variant>
 
 #include "../ast/ast.h"
@@ -10,7 +11,7 @@ namespace tree_interpreter {
   struct NothingValue {};
 
   // Dynamic value model for evaluated expressions, plus operations that define value semantics.
-  using RuntimeValue = std::variant<int64_t, double, bool, NothingValue>;
+  using RuntimeValue = std::variant<int64_t, double, bool, std::string, NothingValue>;
 
   bool IsTruthy(const RuntimeValue& value);
 

--- a/src/tree_interpreter/tree_interpreter.cpp
+++ b/src/tree_interpreter/tree_interpreter.cpp
@@ -192,6 +192,7 @@ namespace tree_interpreter {
           [](const ast::IntegerLiteralExpression& integer_expression) -> RuntimeValue { return integer_expression.value_; },
           [](const ast::DoubleLiteralExpression& double_expression) -> RuntimeValue { return double_expression.value_; },
           [](const ast::BoolLiteralExpression& bool_expression) -> RuntimeValue { return bool_expression.value_; },
+          [](const ast::StringLiteralExpression& string_expression) -> RuntimeValue { return string_expression.value_; },
           [](const ast::NothingLiteralExpression&) -> RuntimeValue { return NothingValue{}; },
           [this](const ast::IdentifierExpression& identifier_expression) -> RuntimeValue {
             return runtime_state_.LookupVariable(identifier_expression.identifier_.name_);

--- a/tests/fail/0067_double_left_modulo.err
+++ b/tests/fail/0067_double_left_modulo.err
@@ -1,1 +1,1 @@
-ExecuteArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers
+ComputeArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers

--- a/tests/fail/0068_double_right_modulo.err
+++ b/tests/fail/0068_double_right_modulo.err
@@ -1,1 +1,1 @@
-ExecuteArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers
+ComputeArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers

--- a/tests/fail/0069_double_modulo_by_zero.err
+++ b/tests/fail/0069_double_modulo_by_zero.err
@@ -1,1 +1,1 @@
-ExecuteArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers
+ComputeArithmeticOperation: unsupported arithmetic operator or modulo attempted with non-integers

--- a/tests/fail/0073_string_arithmetic.ee
+++ b/tests/fail/0073_string_arithmetic.ee
@@ -1,0 +1,3 @@
+fn main() {
+    print("hello" - "h");
+}

--- a/tests/fail/0073_string_arithmetic.err
+++ b/tests/fail/0073_string_arithmetic.err
@@ -1,0 +1,1 @@
+ValidateNumericValue: value must be a double or integer

--- a/tests/fail/0074_string_relational.ee
+++ b/tests/fail/0074_string_relational.ee
@@ -1,0 +1,3 @@
+fn main() {
+    print("a" < "b");
+}

--- a/tests/fail/0074_string_relational.err
+++ b/tests/fail/0074_string_relational.err
@@ -1,0 +1,1 @@
+ValidateNumericValue: value must be a double or integer

--- a/tests/fail/0075_string_modulo.ee
+++ b/tests/fail/0075_string_modulo.ee
@@ -1,0 +1,3 @@
+fn main() {
+    print("abc" % "b");
+}

--- a/tests/fail/0075_string_modulo.err
+++ b/tests/fail/0075_string_modulo.err
@@ -1,0 +1,1 @@
+ValidateNumericValue: value must be a double or integer

--- a/tests/fail/0076_negate_string.ee
+++ b/tests/fail/0076_negate_string.ee
@@ -1,0 +1,3 @@
+fn main() {
+    print(-"hello");
+}

--- a/tests/fail/0076_negate_string.err
+++ b/tests/fail/0076_negate_string.err
@@ -1,0 +1,1 @@
+ValidateNumericValue: value must be a double or integer

--- a/tests/fail/0077_invalid_string_escape.ee
+++ b/tests/fail/0077_invalid_string_escape.ee
@@ -1,0 +1,3 @@
+fn main() {
+    print("bad\q");
+}

--- a/tests/fail/0077_invalid_string_escape.err
+++ b/tests/fail/0077_invalid_string_escape.err
@@ -1,0 +1,1 @@
+ParseFileContentsIntoAST: parse failed at 2:16: syntax error, unexpected 'q', expecting <String>.

--- a/tests/fail/0078_unclosed_string.ee
+++ b/tests/fail/0078_unclosed_string.ee
@@ -1,0 +1,3 @@
+fn main() {
+    print("missing end);
+}

--- a/tests/fail/0078_unclosed_string.err
+++ b/tests/fail/0078_unclosed_string.err
@@ -1,0 +1,1 @@
+ParseFileContentsIntoAST: parse failed at 2:25: syntax error, unexpected '\n', expecting '"'.

--- a/tests/fail/0079_raw_multiline_string.ee
+++ b/tests/fail/0079_raw_multiline_string.ee
@@ -1,0 +1,4 @@
+fn main() {
+    print("line one
+line two");
+}

--- a/tests/fail/0079_raw_multiline_string.err
+++ b/tests/fail/0079_raw_multiline_string.err
@@ -1,0 +1,1 @@
+ParseFileContentsIntoAST: parse failed at 2:20: syntax error, unexpected '\n', expecting '"'.

--- a/tests/pass/0119_print_string_literals.ee
+++ b/tests/pass/0119_print_string_literals.ee
@@ -1,0 +1,6 @@
+fn main() {
+    print("hello");
+    println(" world");
+    println("");
+    println("done");
+}

--- a/tests/pass/0119_print_string_literals.out
+++ b/tests/pass/0119_print_string_literals.out
@@ -1,0 +1,3 @@
+hello world
+
+done

--- a/tests/pass/0120_string_escape_sequences.ee
+++ b/tests/pass/0120_string_escape_sequences.ee
@@ -1,0 +1,5 @@
+fn main() {
+    println("line one\nline two");
+    println("left\tright");
+    println("C:\\tmp\\file");
+}

--- a/tests/pass/0120_string_escape_sequences.out
+++ b/tests/pass/0120_string_escape_sequences.out
@@ -1,0 +1,4 @@
+line one
+line two
+left	right
+C:\tmp\file

--- a/tests/pass/0121_string_variables_assignment_and_scope.ee
+++ b/tests/pass/0121_string_variables_assignment_and_scope.ee
@@ -1,0 +1,11 @@
+fn main() {
+    let message = "outer";
+    println(message);
+    message = "updated";
+    println(message);
+    {
+        let message = "inner";
+        println(message);
+    }
+    println(message);
+}

--- a/tests/pass/0121_string_variables_assignment_and_scope.out
+++ b/tests/pass/0121_string_variables_assignment_and_scope.out
@@ -1,0 +1,4 @@
+outer
+updated
+inner
+updated

--- a/tests/pass/0122_string_equality_truthiness.ee
+++ b/tests/pass/0122_string_equality_truthiness.ee
@@ -1,0 +1,13 @@
+fn main() {
+    println("same" == "same");
+    println("same" != "different");
+    println("" == "");
+    if "text" {
+        println("non-empty truthy");
+    }
+    if "" {
+        println("empty truthy bug");
+    } else {
+        println("empty falsy");
+    }
+}

--- a/tests/pass/0122_string_equality_truthiness.out
+++ b/tests/pass/0122_string_equality_truthiness.out
@@ -1,0 +1,5 @@
+true
+true
+true
+non-empty truthy
+empty falsy

--- a/tests/pass/0123_string_function_arguments_returns.ee
+++ b/tests/pass/0123_string_function_arguments_returns.ee
@@ -1,0 +1,13 @@
+fn identity(value) {
+    return value;
+}
+
+fn implicit() {
+}
+
+fn main() {
+    println(identity("returned"));
+    let text = identity("assigned");
+    println(text);
+    println(implicit() == nothing);
+}

--- a/tests/pass/0123_string_function_arguments_returns.out
+++ b/tests/pass/0123_string_function_arguments_returns.out
@@ -1,0 +1,3 @@
+returned
+assigned
+true

--- a/tests/pass/0124_string_logical_short_circuit.ee
+++ b/tests/pass/0124_string_logical_short_circuit.ee
@@ -1,0 +1,10 @@
+fn explode() {
+    return unknown_function();
+}
+
+fn main() {
+    println("" && explode());
+    println("text" || explode());
+    println(!"");
+    println(!"text");
+}

--- a/tests/pass/0124_string_logical_short_circuit.out
+++ b/tests/pass/0124_string_logical_short_circuit.out
@@ -1,0 +1,4 @@
+false
+true
+true
+false

--- a/tests/pass/0125_string_mixed_type_equality.ee
+++ b/tests/pass/0125_string_mixed_type_equality.ee
@@ -1,0 +1,6 @@
+fn main() {
+    println("1" == 1);
+    println("true" == true);
+    println("nothing" == nothing);
+    println("1" != 1);
+}

--- a/tests/pass/0125_string_mixed_type_equality.out
+++ b/tests/pass/0125_string_mixed_type_equality.out
@@ -1,0 +1,4 @@
+false
+false
+false
+true


### PR DESCRIPTION
## What Changed? Closes #36 
Added strings to the language (no concatenation).

## Why Did You Change It?
Now can print thigns like print("Hello World")!

## How Did You Test It?
Adding passing/failing tests. Ensured all previous tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add first-class string literals to the language. You can print, pass, and compare strings; no concatenation or ordering operations.

- **New Features**
  - Grammar: added `String` token with escape support for `\n`, `\t`, and `\\`; rejects invalid escapes, multiline, and unclosed strings.
  - AST/Interpreter: added `StringLiteralExpression`; runtime now includes `std::string`; print/println output strings; equality works only for string-to-string; empty string is falsy.
  - Docs: README updated with string literal and truthiness semantics.
  - Tests: added pass/fail cases for literals, escapes, variables/scope, functions, logical short-circuit, mixed-type equality (false), and parser errors for bad strings.

<sup>Written for commit 72701536aeba318e9dc3d9512a50aa98652068f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

