### PR TITLE
Updated VM to now be able to call any function in a EE file instead of being forced to start at main.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Scripts:
 ### Source
 
 - `src/main.cpp`: CLI entry point, `--debug` handling, top-level error reporting, and `ee::VM` invocation
-- `src/vm/vm.h`, `src/vm/vm.cpp`: small `ee::VM` wrapper that loads source files, stores the parsed AST, exposes debug AST output, and runs `main`
+- `src/vm/vm.h`, `src/vm/vm.cpp`: small `ee::VM` wrapper that loads source files, stores the parsed AST, exposes debug AST output, and calls named functions
 - `src/parser/language_grammar.h`: PEG grammar string
 - `src/parser/parser.h`: parser interface
 - `src/parser/parser.cpp`: parser construction and semantic actions that build the AST
@@ -128,7 +128,7 @@ For fixtures:
 Current language support:
 
 - multiple top-level functions
-- required zero-argument `fn main()` entry point
+- CLI execution calls a zero-argument `fn main()` entry point
 - function parameters and function calls
 - `print(...)` and `println(...)`
 - `let` declarations with required initializers
@@ -163,7 +163,7 @@ Current language support:
 - `false`, `nothing`, integer `0`, double `0.0`, empty strings, and empty arrays are falsy
 - nonzero integers, nonzero doubles, non-empty strings, non-empty arrays, and `true` are truthy
 - functions implicitly return `nothing` if no `return` executes
-- `main` must exist and must not take parameters
+- `main` is a CLI convention; source files loaded for embedding can define callable functions without `main`
 - function arguments are evaluated left-to-right in the caller before the function is looked up and called
 - each function call creates a fresh call frame
 - parameters and top-level function locals live in the same function scope

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ int main(const int argc, char** argv) {
       std::cout << vm.DebugAstString();
     }
 
-    vm.RunMain();
+    vm.Call("main");
 
     return 0;
   }

--- a/src/tree_interpreter/runtime_state.cpp
+++ b/src/tree_interpreter/runtime_state.cpp
@@ -9,33 +9,26 @@ namespace tree_interpreter {
     runtime_state_.CurrentFrame().scopes_.emplace_back();
   }
 
-  RuntimeState::ScopeGuard::~ScopeGuard() { runtime_state_.CurrentFrame().scopes_.pop_back(); }
+  RuntimeState::ScopeGuard::~ScopeGuard() {
+    runtime_state_.CurrentFrame().scopes_.pop_back();
+  }
 
   RuntimeState::CallFrameGuard::CallFrameGuard(RuntimeState& runtime_state) : runtime_state_(runtime_state) {
     runtime_state_.call_stack_.emplace_back();
   }
 
-  RuntimeState::CallFrameGuard::~CallFrameGuard() { runtime_state_.call_stack_.pop_back(); }
+  RuntimeState::CallFrameGuard::~CallFrameGuard() {
+    runtime_state_.call_stack_.pop_back();
+  }
 
-  const ast::Function& RuntimeState::BuildFunctionTableAndRequireMain(const ast::Program& program) {
+  void RuntimeState::BuildFunctionTable(const ast::Program& program) {
     // Function declarations are global and callable regardless of source order.
     for (const auto& current_function : program.functions_) {
       if (available_functions_.contains(current_function.identifier_.name_)) {
-        throw std::runtime_error("BuildFunctionTableAndRequireMain: duplicate function '" + current_function.identifier_.name_ + "'");
+        throw std::runtime_error("BuildFunctionTable: duplicate function '" + current_function.identifier_.name_ + "'");
       }
       available_functions_.emplace(current_function.identifier_.name_, &current_function);
     }
-
-    if (!available_functions_.contains("main")) {
-      throw std::runtime_error("BuildFunctionTableAndRequireMain: no main function found");
-    }
-
-    // TODO: Remove once we allow command line arguments
-    if (!available_functions_.at("main")->parameters_.empty()) {
-      throw std::runtime_error("BuildFunctionTableAndRequireMain: main function must not take parameters");
-    }
-
-    return *available_functions_.at("main");
   }
 
   const ast::Function& RuntimeState::LookupFunctionOrThrow(const std::string& function_name) const {
@@ -78,7 +71,11 @@ namespace tree_interpreter {
     throw std::runtime_error("ExecuteStatement: variable '" + variable_name + "' is not declared");
   }
 
-  CallFrame& RuntimeState::CurrentFrame() { return call_stack_.back(); }
+  CallFrame& RuntimeState::CurrentFrame() {
+    return call_stack_.back();
+  }
 
-  Scope& RuntimeState::CurrentScope() { return CurrentFrame().scopes_.back(); }
+  Scope& RuntimeState::CurrentScope() {
+    return CurrentFrame().scopes_.back();
+  }
 } // namespace tree_interpreter

--- a/src/tree_interpreter/runtime_state.h
+++ b/src/tree_interpreter/runtime_state.h
@@ -48,7 +48,7 @@ namespace tree_interpreter {
       RuntimeState& runtime_state_;
     };
 
-    const ast::Function& BuildFunctionTableAndRequireMain(const ast::Program& program);
+    void BuildFunctionTable(const ast::Program& program);
 
     const ast::Function& LookupFunctionOrThrow(const std::string& function_name) const;
 

--- a/src/tree_interpreter/tree_interpreter.cpp
+++ b/src/tree_interpreter/tree_interpreter.cpp
@@ -15,348 +15,322 @@
 #include "tree_interpreter.h"
 
 namespace tree_interpreter {
-  enum class ControlFlow { kNormal, kReturn, kContinue, kBreak };
+  Interpreter::Interpreter(const ast::Program& program) {
+    runtime_state_.BuildFunctionTable(program);
+  }
 
-  struct ExecutionResult {
-    ControlFlow control_flow_ = ControlFlow::kNormal;
-    std::optional<RuntimeValue> return_value_ = std::nullopt;
-  };
+  RuntimeValue Interpreter::ExecuteFunction(const std::string& function_name, std::span<const RuntimeValue> arguments) {
+    const ast::Function& function = runtime_state_.LookupFunctionOrThrow(function_name);
 
-  class Interpreter {
-   public:
-    void Run(const ast::Program& program) {
-      const ast::Function& main_function = runtime_state_.BuildFunctionTableAndRequireMain(program);
-      ExecuteFunction(main_function, {});
+    if (arguments.size() != function.parameters_.size()) {
+      throw std::runtime_error("ExecuteFunction: argument count doesn't match parameter count");
     }
 
-   private:
-    RuntimeState runtime_state_;
-
-    std::pair<RuntimeValue, RuntimeValue>
-    EvaluateBothOperands(const ast::ExpressionPointer& left_operand, const ast::ExpressionPointer& right_operand) {
-      return {EvaluateExpression(*left_operand), EvaluateExpression(*right_operand)};
+    RuntimeState::CallFrameGuard call_frame_guard(runtime_state_);
+    RuntimeState::ScopeGuard function_level_scope(runtime_state_);
+    // Parameters are ordinary variables in the function's top-level lexical scope.
+    for (auto&& [parameter, argument] : std::views::zip(function.parameters_, arguments)) {
+      runtime_state_.DeclareVariable(parameter.name_, argument);
     }
 
-    std::pair<RuntimeValue, RuntimeValue>
-    EvaluateBothOperandsAsNumerics(const ast::ExpressionPointer& left_operand, const ast::ExpressionPointer& right_operand) {
-      const auto [left_value, right_value] = EvaluateBothOperands(left_operand, right_operand);
+    const auto [control_flow, return_value] = ExecuteBlock(function.function_block_, BlockScope::kReuseScope);
 
-      // Arithmetic and relational operators accept only numeric operands.
-      ValidateNumericValue(left_value);
-      ValidateNumericValue(right_value);
-
-      return {left_value, right_value};
+    switch (control_flow) {
+      case ControlFlow::kNormal: return NothingValue{};
+      case ControlFlow::kReturn: return return_value ? *return_value : NothingValue{};
+      case ControlFlow::kContinue: throw std::runtime_error("ExecuteFunction: continue statement not within a loop");
+      case ControlFlow::kBreak: throw std::runtime_error("ExecuteFunction: break statement not within a loop");
     }
 
-    RuntimeValue ExecuteFunction(const ast::Function& function, std::span<const RuntimeValue> arguments) {
-      if (arguments.size() != function.parameters_.size()) {
-        throw std::runtime_error("ExecuteFunction: argument count doesn't match parameter count");
+    throw std::runtime_error("ExecuteFunction: unknown control flow");
+  }
+
+  std::pair<RuntimeValue, RuntimeValue>
+  Interpreter::EvaluateBothOperands(const ast::ExpressionPointer& left_operand, const ast::ExpressionPointer& right_operand) {
+    return {EvaluateExpression(*left_operand), EvaluateExpression(*right_operand)};
+  }
+
+  std::pair<RuntimeValue, RuntimeValue>
+  Interpreter::EvaluateBothOperandsAsNumerics(const ast::ExpressionPointer& left_operand, const ast::ExpressionPointer& right_operand) {
+    const auto [left_value, right_value] = EvaluateBothOperands(left_operand, right_operand);
+
+    // Arithmetic and relational operators accept only numeric operands.
+    ValidateNumericValue(left_value);
+    ValidateNumericValue(right_value);
+
+    return {left_value, right_value};
+  }
+
+  ExecutionResult Interpreter::ExecuteStatementsInBlock(const ast::BlockPointer& block_pointer) {
+    ExecutionResult execution_result;
+    for (const auto& statement_variant : block_pointer->statements_) {
+      execution_result = ExecuteStatement(statement_variant);
+      if (execution_result.control_flow_ != ControlFlow::kNormal) {
+        break;
       }
+    }
+    return execution_result;
+  }
 
-      RuntimeState::CallFrameGuard call_frame_guard(runtime_state_);
-      RuntimeState::ScopeGuard function_level_scope(runtime_state_);
-      // Parameters are ordinary variables in the function's top-level lexical scope.
-      for (auto&& [parameter, argument] : std::views::zip(function.parameters_, arguments)) {
-        runtime_state_.DeclareVariable(parameter.name_, argument);
-      }
-
-      const auto [control_flow, return_value] = ExecuteBlock(function.function_block_, BlockScope::kReuseScope);
-
-      switch (control_flow) {
-        case ControlFlow::kNormal: return NothingValue{};
-        case ControlFlow::kReturn: return return_value ? *return_value : NothingValue{};
-        case ControlFlow::kContinue: throw std::runtime_error("ExecuteFunction: continue statement not within a loop");
-        case ControlFlow::kBreak: throw std::runtime_error("ExecuteFunction: break statement not within a loop");
-      }
-
-      throw std::runtime_error("ExecuteFunction: unknown control flow");
+  ExecutionResult Interpreter::ExecuteBlock(const ast::BlockPointer& block_pointer, const BlockScope block_scope_behavior) {
+    if (!block_pointer) {
+      throw std::runtime_error("ExecuteBlock: null block pointer");
     }
 
-    ExecutionResult ExecuteStatementsInBlock(const ast::BlockPointer& block_pointer) {
-      ExecutionResult execution_result;
-      for (const auto& statement_variant : block_pointer->statements_) {
-        execution_result = ExecuteStatement(statement_variant);
-        if (execution_result.control_flow_ != ControlFlow::kNormal) {
-          break;
-        }
-      }
-      return execution_result;
-    }
+    // Function bodies reuse the scope created for parameters; nested blocks create their own lexical scope.
+    if (block_scope_behavior == BlockScope::kCreateScope) {
+      RuntimeState::ScopeGuard block_scope(runtime_state_);
 
-    enum class BlockScope { kCreateScope, kReuseScope };
-
-    ExecutionResult ExecuteBlock(const ast::BlockPointer& block_pointer, const BlockScope block_scope_behavior = BlockScope::kCreateScope) {
-      if (!block_pointer) {
-        throw std::runtime_error("ExecuteBlock: null block pointer");
-      }
-
-      // Function bodies reuse the scope created for parameters; nested blocks create their own lexical scope.
-      if (block_scope_behavior == BlockScope::kCreateScope) {
-        RuntimeState::ScopeGuard block_scope(runtime_state_);
-
-        return ExecuteStatementsInBlock(block_pointer);
-      }
       return ExecuteStatementsInBlock(block_pointer);
     }
+    return ExecuteStatementsInBlock(block_pointer);
+  }
 
-    struct IndexedSlotLocation {
-      RuntimeArrayPointer array_;
-      size_t index_;
-    };
+  IndexedSlotLocation Interpreter::LocateIndexedSlot(const ast::IndexExpression& index_expression) {
+    RuntimeValue current_array = EvaluateExpression(*index_expression.indexed_expression_);
 
-    IndexedSlotLocation LocateIndexedSlot(const ast::IndexExpression& index_expression) {
-      RuntimeValue current_array = EvaluateExpression(*index_expression.indexed_expression_);
-
-      const size_t index_expression_count = index_expression.indexing_expressions_.size();
-      for (size_t index_expression_index = 0; index_expression_index < index_expression_count; ++index_expression_index) {
-        const auto* current_array_pointer = std::get_if<RuntimeArrayPointer>(&current_array);
-        if (!current_array_pointer || !*current_array_pointer) {
-          throw std::runtime_error("LocateIndexedSlot: cannot index into a non-array value");
-        }
-
-        const RuntimeValue index_value = EvaluateExpression(*index_expression.indexing_expressions_[index_expression_index]);
-        const auto* index_pointer = std::get_if<int64_t>(&index_value);
-        if (!index_pointer) {
-          throw std::runtime_error("LocateIndexedSlot: index must be an integer");
-        }
-        if (*index_pointer < 0 || static_cast<size_t>(*index_pointer) >= (*current_array_pointer)->elements_.size()) {
-          throw std::runtime_error("LocateIndexedSlot: index " + std::to_string(*index_pointer) + " out of bounds");
-        }
-
-        const auto element_index = static_cast<size_t>(*index_pointer);
-        if (index_expression_index == index_expression_count - 1) {
-          return IndexedSlotLocation{.array_ = *current_array_pointer, .index_ = element_index};
-        }
-
-        current_array = (*current_array_pointer)->elements_[element_index];
+    const size_t index_expression_count = index_expression.indexing_expressions_.size();
+    for (size_t index_expression_index = 0; index_expression_index < index_expression_count; ++index_expression_index) {
+      const auto* current_array_pointer = std::get_if<RuntimeArrayPointer>(&current_array);
+      if (!current_array_pointer || !*current_array_pointer) {
+        throw std::runtime_error("LocateIndexedSlot: cannot index into a non-array value");
       }
 
-      throw std::runtime_error("LocateIndexedSlot: index expression has no indexing expressions");
+      const RuntimeValue index_value = EvaluateExpression(*index_expression.indexing_expressions_[index_expression_index]);
+      const auto* index_pointer = std::get_if<int64_t>(&index_value);
+      if (!index_pointer) {
+        throw std::runtime_error("LocateIndexedSlot: index must be an integer");
+      }
+      if (*index_pointer < 0 || static_cast<size_t>(*index_pointer) >= (*current_array_pointer)->elements_.size()) {
+        throw std::runtime_error("LocateIndexedSlot: index " + std::to_string(*index_pointer) + " out of bounds");
+      }
+
+      const auto element_index = static_cast<size_t>(*index_pointer);
+      if (index_expression_index == index_expression_count - 1) {
+        return IndexedSlotLocation{.array_ = *current_array_pointer, .index_ = element_index};
+      }
+
+      current_array = (*current_array_pointer)->elements_[element_index];
     }
 
-    ExecutionResult ExecuteStatement(const ast::StatementVariant& statement_variant) {
-      return std::visit(
-        template_helpers::Overloaded{
-          [this](const ast::PrintStatement& print_statement) {
-            if (print_statement.print_expression_) {
-              PrintValue(EvaluateExpression(*print_statement.print_expression_));
-            }
-            if (print_statement.new_line_) {
-              std::cout << "\n";
-            }
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::LetStatement& let_statement) {
-            runtime_state_.DeclareVariable(let_statement.identifier_.name_, EvaluateExpression(let_statement.initializer_expression_));
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::AssignmentStatement& assignment_statement) {
-            runtime_state_.AssignVariable(
-              assignment_statement.identifier_.name_, EvaluateExpression(assignment_statement.assigned_expression_)
-            );
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::IfStatement& if_statement) {
-            if (IsTruthy(EvaluateExpression(if_statement.if_condition_))) {
-              return ExecuteBlock(if_statement.if_block_);
-            }
+    throw std::runtime_error("LocateIndexedSlot: index expression has no indexing expressions");
+  }
 
-            for (const auto& [else_if_condition, else_if_block] : if_statement.else_if_branches_) {
-              if (IsTruthy(EvaluateExpression(else_if_condition))) {
-                return ExecuteBlock(else_if_block);
-              }
-            }
-
-            if (if_statement.else_block_) {
-              return ExecuteBlock(*if_statement.else_block_);
-            }
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::WhileStatement& while_statement) {
-            while (IsTruthy(EvaluateExpression(while_statement.while_condition_))) {
-              const ExecutionResult execution_result = ExecuteBlock(while_statement.while_block_);
-
-              switch (execution_result.control_flow_) {
-                case ControlFlow::kNormal:
-                case ControlFlow::kContinue: continue;
-                case ControlFlow::kBreak: return ExecutionResult{ControlFlow::kNormal};
-                case ControlFlow::kReturn: return execution_result;
-              }
-            }
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::ForStatement& for_statement) {
-            // Must add scope for initializer variable (needs to live past loop iterations).
-            RuntimeState::ScopeGuard initializer_variable_scope(runtime_state_);
-            ExecuteStatement(for_statement.initializer_);
-
-            while (IsTruthy(EvaluateExpression(for_statement.condition_))) {
-              const ExecutionResult execution_result = ExecuteBlock(for_statement.for_block_);
-
-              switch (execution_result.control_flow_) {
-                case ControlFlow::kBreak: return ExecutionResult{ControlFlow::kNormal};
-                case ControlFlow::kReturn: return execution_result;
-                case ControlFlow::kNormal:
-                case ControlFlow::kContinue: ExecuteStatement(for_statement.update_);
-              }
-            }
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [](const ast::ContinueStatement&) { return ExecutionResult{ControlFlow::kContinue}; },
-          [](const ast::BreakStatement&) { return ExecutionResult{ControlFlow::kBreak}; },
-          [this](const ast::ReturnStatement& return_statement) {
-            return ExecutionResult{
-              ControlFlow::kReturn,
-              return_statement.return_expression_ ? EvaluateExpression(*return_statement.return_expression_) : NothingValue{}
-            };
-          },
-          [this](const ast::FunctionCallStatement& function_call_statement) {
-            EvaluateExpression(function_call_statement.function_call_);
-            // Function call statements discard return values and run only for side effects.
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::PushStatement& push_statement) {
-            EvaluateExpression(push_statement.push_expression_);
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::PopStatement& pop_statement) {
-            EvaluateExpression(pop_statement.pop_expression_);
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::IndexAssignmentStatement& index_assignment_statement) {
-            const auto [final_array_pointer, final_index] = LocateIndexedSlot(index_assignment_statement.target_);
-
-            final_array_pointer->elements_[final_index] = EvaluateExpression(*index_assignment_statement.assigned_expression_);
-
-            return ExecutionResult{ControlFlow::kNormal};
-          },
-          [this](const ast::BlockPointer& block_pointer) { return ExecuteBlock(block_pointer); },
+  ExecutionResult Interpreter::ExecuteStatement(const ast::StatementVariant& statement_variant) {
+    return std::visit(
+      template_helpers::Overloaded{
+        [this](const ast::PrintStatement& print_statement) {
+          if (print_statement.print_expression_) {
+            PrintValue(EvaluateExpression(*print_statement.print_expression_));
+          }
+          if (print_statement.new_line_) {
+            std::cout << "\n";
+          }
+          return ExecutionResult{ControlFlow::kNormal};
         },
-        statement_variant
-      );
-    }
+        [this](const ast::LetStatement& let_statement) {
+          runtime_state_.DeclareVariable(let_statement.identifier_.name_, EvaluateExpression(let_statement.initializer_expression_));
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::AssignmentStatement& assignment_statement) {
+          runtime_state_.AssignVariable(
+            assignment_statement.identifier_.name_, EvaluateExpression(assignment_statement.assigned_expression_)
+          );
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::IfStatement& if_statement) {
+          if (IsTruthy(EvaluateExpression(if_statement.if_condition_))) {
+            return ExecuteBlock(if_statement.if_block_);
+          }
 
-    RuntimeValue EvaluateExpression(const ast::ExpressionVariant& expression_variant) {
-      return std::visit(
-        template_helpers::Overloaded{
-          [](const ast::IntegerLiteralExpression& integer_expression) -> RuntimeValue { return integer_expression.value_; },
-          [](const ast::DoubleLiteralExpression& double_expression) -> RuntimeValue { return double_expression.value_; },
-          [](const ast::BoolLiteralExpression& bool_expression) -> RuntimeValue { return bool_expression.value_; },
-          [](const ast::StringLiteralExpression& string_expression) -> RuntimeValue { return string_expression.value_; },
-          [this](const ast::ArrayLiteralExpression& array_expression) -> RuntimeValue {
-            std::vector<RuntimeValue> evaluated_array_elements;
-            evaluated_array_elements.reserve(array_expression.elements_.size());
-
-            std::ranges::transform(array_expression.elements_, std::back_inserter(evaluated_array_elements), [this](const auto& element) {
-              return EvaluateExpression(*element);
-            });
-
-            return std::make_shared<RuntimeArray>(RuntimeArray{std::move(evaluated_array_elements)});
-          },
-          [](const ast::NothingLiteralExpression&) -> RuntimeValue { return NothingValue{}; },
-          [this](const ast::IdentifierExpression& identifier_expression) -> RuntimeValue {
-            return runtime_state_.LookupVariable(identifier_expression.identifier_.name_);
-          },
-          [this](const ast::ArithmeticExpression& arithmetic_expression) -> RuntimeValue {
-            const auto [left_value, right_value] =
-              EvaluateBothOperandsAsNumerics(arithmetic_expression.left_operand_, arithmetic_expression.right_operand_);
-
-            return ExecuteArithmeticOperation(left_value, arithmetic_expression.operator_, right_value);
-          },
-          [this](const ast::RelationalExpression& relational_expression) -> RuntimeValue {
-            const auto [left_value, right_value] =
-              EvaluateBothOperandsAsNumerics(relational_expression.left_operand_, relational_expression.right_operand_);
-            return ExecuteRelationalOperation(left_value, relational_expression.operator_, right_value);
-          },
-          [this](const ast::EqualityExpression& equality_expression) -> RuntimeValue {
-            const auto [left_value, right_value] =
-              EvaluateBothOperands(equality_expression.left_operand_, equality_expression.right_operand_);
-            return ExecuteEqualityOperation(left_value, equality_expression.operator_, right_value);
-          },
-          [this](const ast::LogicalExpression& logical_expression) -> RuntimeValue {
-            const bool left_truthiness = IsTruthy(EvaluateExpression(*logical_expression.left_operand_));
-
-            // Preserve short-circuiting so the right operand is evaluated only when needed.
-            if (logical_expression.operator_ == ast::LogicalOperator::kAnd && !left_truthiness) {
-              return false;
+          for (const auto& [else_if_condition, else_if_block] : if_statement.else_if_branches_) {
+            if (IsTruthy(EvaluateExpression(else_if_condition))) {
+              return ExecuteBlock(else_if_block);
             }
-            if (logical_expression.operator_ == ast::LogicalOperator::kOr && left_truthiness) {
-              return true;
-            }
+          }
 
-            return ExecuteLogicalOperation(
-              left_truthiness, logical_expression.operator_, IsTruthy(EvaluateExpression(*logical_expression.right_operand_))
-            );
-          },
-          [this](const ast::UnaryExpression& unary_expression) -> RuntimeValue {
-            return ExecuteUnaryOperation(unary_expression.operator_, EvaluateExpression(*unary_expression.operand_));
-          },
-          [this](const ast::LengthExpression& length_expression) -> RuntimeValue {
-            const RuntimeValue length_operand = EvaluateExpression(*length_expression.expression_);
-            return std::visit(
-              template_helpers::Overloaded{
-                [](const std::string& string_operand) -> RuntimeValue { return static_cast<int64_t>(string_operand.size()); },
-                [](const RuntimeArrayPointer& array_operand) -> RuntimeValue {
-                  return static_cast<int64_t>(array_operand->elements_.size());
-                },
-                [](const auto&) -> RuntimeValue { throw std::runtime_error("EvaluateExpression: can only take length of string or array"); }
+          if (if_statement.else_block_) {
+            return ExecuteBlock(*if_statement.else_block_);
+          }
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::WhileStatement& while_statement) {
+          while (IsTruthy(EvaluateExpression(while_statement.while_condition_))) {
+            const ExecutionResult execution_result = ExecuteBlock(while_statement.while_block_);
+
+            switch (execution_result.control_flow_) {
+              case ControlFlow::kNormal:
+              case ControlFlow::kContinue: continue;
+              case ControlFlow::kBreak: return ExecutionResult{ControlFlow::kNormal};
+              case ControlFlow::kReturn: return execution_result;
+            }
+          }
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::ForStatement& for_statement) {
+          // Must add scope for initializer variable (needs to live past loop iterations).
+          RuntimeState::ScopeGuard initializer_variable_scope(runtime_state_);
+          ExecuteStatement(for_statement.initializer_);
+
+          while (IsTruthy(EvaluateExpression(for_statement.condition_))) {
+            const ExecutionResult execution_result = ExecuteBlock(for_statement.for_block_);
+
+            switch (execution_result.control_flow_) {
+              case ControlFlow::kBreak: return ExecutionResult{ControlFlow::kNormal};
+              case ControlFlow::kReturn: return execution_result;
+              case ControlFlow::kNormal:
+              case ControlFlow::kContinue: ExecuteStatement(for_statement.update_);
+            }
+          }
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [](const ast::ContinueStatement&) { return ExecutionResult{ControlFlow::kContinue}; },
+        [](const ast::BreakStatement&) { return ExecutionResult{ControlFlow::kBreak}; },
+        [this](const ast::ReturnStatement& return_statement) {
+          return ExecutionResult{
+            ControlFlow::kReturn,
+            return_statement.return_expression_ ? EvaluateExpression(*return_statement.return_expression_) : NothingValue{}
+          };
+        },
+        [this](const ast::FunctionCallStatement& function_call_statement) {
+          EvaluateExpression(function_call_statement.function_call_);
+          // Function call statements discard return values and run only for side effects.
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::PushStatement& push_statement) {
+          EvaluateExpression(push_statement.push_expression_);
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::PopStatement& pop_statement) {
+          EvaluateExpression(pop_statement.pop_expression_);
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::IndexAssignmentStatement& index_assignment_statement) {
+          const auto [final_array_pointer, final_index] = LocateIndexedSlot(index_assignment_statement.target_);
+
+          final_array_pointer->elements_[final_index] = EvaluateExpression(*index_assignment_statement.assigned_expression_);
+
+          return ExecutionResult{ControlFlow::kNormal};
+        },
+        [this](const ast::BlockPointer& block_pointer) { return ExecuteBlock(block_pointer); },
+      },
+      statement_variant
+    );
+  }
+
+  RuntimeValue Interpreter::EvaluateExpression(const ast::ExpressionVariant& expression_variant) {
+    return std::visit(
+      template_helpers::Overloaded{
+        [](const ast::IntegerLiteralExpression& integer_expression) -> RuntimeValue { return integer_expression.value_; },
+        [](const ast::DoubleLiteralExpression& double_expression) -> RuntimeValue { return double_expression.value_; },
+        [](const ast::BoolLiteralExpression& bool_expression) -> RuntimeValue { return bool_expression.value_; },
+        [](const ast::StringLiteralExpression& string_expression) -> RuntimeValue { return string_expression.value_; },
+        [this](const ast::ArrayLiteralExpression& array_expression) -> RuntimeValue {
+          std::vector<RuntimeValue> evaluated_array_elements;
+          evaluated_array_elements.reserve(array_expression.elements_.size());
+
+          std::ranges::transform(array_expression.elements_, std::back_inserter(evaluated_array_elements), [this](const auto& element) {
+            return EvaluateExpression(*element);
+          });
+
+          return std::make_shared<RuntimeArray>(RuntimeArray{std::move(evaluated_array_elements)});
+        },
+        [](const ast::NothingLiteralExpression&) -> RuntimeValue { return NothingValue{}; },
+        [this](const ast::IdentifierExpression& identifier_expression) -> RuntimeValue {
+          return runtime_state_.LookupVariable(identifier_expression.identifier_.name_);
+        },
+        [this](const ast::ArithmeticExpression& arithmetic_expression) -> RuntimeValue {
+          const auto [left_value, right_value] =
+            EvaluateBothOperandsAsNumerics(arithmetic_expression.left_operand_, arithmetic_expression.right_operand_);
+
+          return ExecuteArithmeticOperation(left_value, arithmetic_expression.operator_, right_value);
+        },
+        [this](const ast::RelationalExpression& relational_expression) -> RuntimeValue {
+          const auto [left_value, right_value] =
+            EvaluateBothOperandsAsNumerics(relational_expression.left_operand_, relational_expression.right_operand_);
+          return ExecuteRelationalOperation(left_value, relational_expression.operator_, right_value);
+        },
+        [this](const ast::EqualityExpression& equality_expression) -> RuntimeValue {
+          const auto [left_value, right_value] =
+            EvaluateBothOperands(equality_expression.left_operand_, equality_expression.right_operand_);
+          return ExecuteEqualityOperation(left_value, equality_expression.operator_, right_value);
+        },
+        [this](const ast::LogicalExpression& logical_expression) -> RuntimeValue {
+          const bool left_truthiness = IsTruthy(EvaluateExpression(*logical_expression.left_operand_));
+
+          // Preserve short-circuiting so the right operand is evaluated only when needed.
+          if (logical_expression.operator_ == ast::LogicalOperator::kAnd && !left_truthiness) {
+            return false;
+          }
+          if (logical_expression.operator_ == ast::LogicalOperator::kOr && left_truthiness) {
+            return true;
+          }
+
+          return ExecuteLogicalOperation(
+            left_truthiness, logical_expression.operator_, IsTruthy(EvaluateExpression(*logical_expression.right_operand_))
+          );
+        },
+        [this](const ast::UnaryExpression& unary_expression) -> RuntimeValue {
+          return ExecuteUnaryOperation(unary_expression.operator_, EvaluateExpression(*unary_expression.operand_));
+        },
+        [this](const ast::LengthExpression& length_expression) -> RuntimeValue {
+          const RuntimeValue length_operand = EvaluateExpression(*length_expression.expression_);
+          return std::visit(
+            template_helpers::Overloaded{
+              [](const std::string& string_operand) -> RuntimeValue { return static_cast<int64_t>(string_operand.size()); },
+              [](const RuntimeArrayPointer& array_operand) -> RuntimeValue {
+                return static_cast<int64_t>(array_operand->elements_.size());
               },
-              length_operand
-            );
-          },
-          [this](const ast::PushExpression& push_expression) -> RuntimeValue {
-            const RuntimeValue target_value = EvaluateExpression(*push_expression.target_);
-            const auto* target_array_pointer = std::get_if<RuntimeArrayPointer>(&target_value);
-            if (!target_array_pointer || !*target_array_pointer) {
-              throw std::runtime_error("EvaluateExpression: can only push to an array");
-            }
-
-            const RuntimeValue pushed_value = EvaluateExpression(*push_expression.pushed_expression_);
-            (*target_array_pointer)->elements_.push_back(pushed_value);
-
-            return NothingValue{};
-          },
-          [this](const ast::PopExpression& pop_expression) -> RuntimeValue {
-            const RuntimeValue target_value = EvaluateExpression(*pop_expression.target_);
-            const auto* target_array_pointer = std::get_if<RuntimeArrayPointer>(&target_value);
-            if (!target_array_pointer || !*target_array_pointer) {
-              throw std::runtime_error("EvaluateExpression: can only pop from an array");
-            }
-
-            if ((*target_array_pointer)->elements_.empty()) {
-              throw std::runtime_error("EvaluateExpression: cannot pop from an empty array");
-            }
-
-            const RuntimeValue popped_value = (*target_array_pointer)->elements_.back();
-            (*target_array_pointer)->elements_.pop_back();
-
-            return popped_value;
-          },
-          [this](const ast::FunctionCallExpression& function_call_expression) -> RuntimeValue {
-            std::vector<RuntimeValue> evaluated_arguments;
-            evaluated_arguments.reserve(function_call_expression.arguments_.size());
-
-            std::ranges::transform(
-              function_call_expression.arguments_, std::back_inserter(evaluated_arguments),
-              [this](const auto& argument) { return EvaluateExpression(*argument); }
-            );
-
-            return ExecuteFunction(
-              runtime_state_.LookupFunctionOrThrow(function_call_expression.function_name_.name_), evaluated_arguments
-            );
-          },
-          [this](const ast::IndexExpression& index_expression) -> RuntimeValue {
-            const auto [final_array_pointer, final_index] = LocateIndexedSlot(index_expression);
-            return final_array_pointer->elements_[final_index];
-          },
+              [](const auto&) -> RuntimeValue { throw std::runtime_error("EvaluateExpression: can only take length of string or array"); }
+            },
+            length_operand
+          );
         },
-        expression_variant
-      );
-    }
-  };
+        [this](const ast::PushExpression& push_expression) -> RuntimeValue {
+          const RuntimeValue target_value = EvaluateExpression(*push_expression.target_);
+          const auto* target_array_pointer = std::get_if<RuntimeArrayPointer>(&target_value);
+          if (!target_array_pointer || !*target_array_pointer) {
+            throw std::runtime_error("EvaluateExpression: can only push to an array");
+          }
 
-  void ExecuteAstWithTreeInterpreter(const ast::Program& program) {
-    Interpreter interpreter;
-    interpreter.Run(program);
+          const RuntimeValue pushed_value = EvaluateExpression(*push_expression.pushed_expression_);
+          (*target_array_pointer)->elements_.push_back(pushed_value);
+
+          return NothingValue{};
+        },
+        [this](const ast::PopExpression& pop_expression) -> RuntimeValue {
+          const RuntimeValue target_value = EvaluateExpression(*pop_expression.target_);
+          const auto* target_array_pointer = std::get_if<RuntimeArrayPointer>(&target_value);
+          if (!target_array_pointer || !*target_array_pointer) {
+            throw std::runtime_error("EvaluateExpression: can only pop from an array");
+          }
+
+          if ((*target_array_pointer)->elements_.empty()) {
+            throw std::runtime_error("EvaluateExpression: cannot pop from an empty array");
+          }
+
+          const RuntimeValue popped_value = (*target_array_pointer)->elements_.back();
+          (*target_array_pointer)->elements_.pop_back();
+
+          return popped_value;
+        },
+        [this](const ast::FunctionCallExpression& function_call_expression) -> RuntimeValue {
+          std::vector<RuntimeValue> evaluated_arguments;
+          evaluated_arguments.reserve(function_call_expression.arguments_.size());
+
+          std::ranges::transform(
+            function_call_expression.arguments_, std::back_inserter(evaluated_arguments),
+            [this](const auto& argument) { return EvaluateExpression(*argument); }
+          );
+
+          return ExecuteFunction(function_call_expression.function_name_.name_, evaluated_arguments);
+        },
+        [this](const ast::IndexExpression& index_expression) -> RuntimeValue {
+          const auto [final_array_pointer, final_index] = LocateIndexedSlot(index_expression);
+          return final_array_pointer->elements_[final_index];
+        },
+      },
+      expression_variant
+    );
   }
 } // namespace tree_interpreter

--- a/src/tree_interpreter/tree_interpreter.h
+++ b/src/tree_interpreter/tree_interpreter.h
@@ -1,10 +1,55 @@
 #ifndef tree_interpreter_H
 #define tree_interpreter_H
 
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <utility>
+
 #include "../ast/ast.h"
+#include "runtime_state.h"
+#include "runtime_value.h"
 
 namespace tree_interpreter {
-  void ExecuteAstWithTreeInterpreter(const ast::Program& program);
-}
+  enum class ControlFlow { kNormal, kReturn, kContinue, kBreak };
+
+  struct ExecutionResult {
+    ControlFlow control_flow_ = ControlFlow::kNormal;
+    std::optional<RuntimeValue> return_value_ = std::nullopt;
+  };
+
+  enum class BlockScope { kCreateScope, kReuseScope };
+
+  struct IndexedSlotLocation {
+    RuntimeArrayPointer array_;
+    size_t index_;
+  };
+
+  class Interpreter {
+   public:
+    explicit Interpreter(const ast::Program& program);
+
+    RuntimeValue ExecuteFunction(const std::string& function_name, std::span<const RuntimeValue> arguments);
+
+   private:
+    RuntimeState runtime_state_;
+
+    std::pair<RuntimeValue, RuntimeValue>
+    EvaluateBothOperands(const ast::ExpressionPointer& left_operand, const ast::ExpressionPointer& right_operand);
+
+    std::pair<RuntimeValue, RuntimeValue>
+    EvaluateBothOperandsAsNumerics(const ast::ExpressionPointer& left_operand, const ast::ExpressionPointer& right_operand);
+
+    ExecutionResult ExecuteStatementsInBlock(const ast::BlockPointer& block_pointer);
+
+    ExecutionResult ExecuteBlock(const ast::BlockPointer& block_pointer, BlockScope block_scope_behavior = BlockScope::kCreateScope);
+
+    IndexedSlotLocation LocateIndexedSlot(const ast::IndexExpression& index_expression);
+
+    ExecutionResult ExecuteStatement(const ast::StatementVariant& statement_variant);
+
+    RuntimeValue EvaluateExpression(const ast::ExpressionVariant& expression_variant);
+  };
+} // namespace tree_interpreter
 
 #endif // tree_interpreter_H

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -23,7 +24,8 @@ namespace ee {
 
   void VM::LoadFile(const std::filesystem::path& file_path) {
     const std::string file_contents = ReadFile(file_path); // we define this bc ParseFileContentsIntoAst takes a string_view
-    program_ast_ = parser::ParseFileContentsIntoAST(file_contents);
+    program_ast_ = std::make_unique<ast::Program>(parser::ParseFileContentsIntoAST(file_contents));
+    interpreter_ = tree_interpreter::Interpreter{*program_ast_};
   }
 
   std::string VM::DebugAstString() const {
@@ -33,10 +35,11 @@ namespace ee {
     return ast_walk::ToString(*program_ast_);
   }
 
-  void VM::RunMain() const {
-    if (!program_ast_) {
-      throw std::runtime_error("RunMain: no program loaded");
+  void VM::Call(const std::string& function_name) {
+    if (!interpreter_) {
+      throw std::runtime_error("VM::Call: load file hasn't been called to establish proper context");
     }
-    tree_interpreter::ExecuteAstWithTreeInterpreter(*program_ast_);
+    [[maybe_unused]] tree_interpreter::RuntimeValue return_value = interpreter_->ExecuteFunction(function_name, {});
   }
+
 } // namespace ee

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -2,10 +2,12 @@
 #define vm_H
 
 #include <filesystem>
+#include <memory>
 #include <optional>
 #include <string>
 
 #include "../ast/ast.h"
+#include "../tree_interpreter/tree_interpreter.h"
 
 namespace ee {
   class VM {
@@ -14,10 +16,11 @@ namespace ee {
 
     [[nodiscard]] std::string DebugAstString() const;
 
-    void RunMain() const;
+    void Call(const std::string& function_name);
 
    private:
-    std::optional<ast::Program> program_ast_;
+    std::unique_ptr<ast::Program> program_ast_;
+    std::optional<tree_interpreter::Interpreter> interpreter_;
   };
 } // namespace ee
 

--- a/tests/fail/0004_no_function_parenthesis.ee
+++ b/tests/fail/0004_no_function_parenthesis.ee
@@ -1,3 +1,3 @@
-fn notMain() {
+fn notMain {
     print(1);
 }

--- a/tests/fail/0004_no_function_parenthesis.err
+++ b/tests/fail/0004_no_function_parenthesis.err
@@ -1,0 +1,1 @@
+ParseFileContentsIntoAST: parse failed at 1:12: syntax error, unexpected '{', expecting '('.

--- a/tests/fail/0004_no_main_function.err
+++ b/tests/fail/0004_no_main_function.err
@@ -1,1 +1,0 @@
-BuildFunctionTableAndRequireMain: no main function found

--- a/tests/fail/0047_duplicate_function_name.err
+++ b/tests/fail/0047_duplicate_function_name.err
@@ -1,1 +1,1 @@
-BuildFunctionTableAndRequireMain: duplicate function 'foo'
+BuildFunctionTable: duplicate function 'foo'

--- a/tests/fail/0057_main_must_not_take_parameters.ee
+++ b/tests/fail/0057_main_must_not_take_parameters.ee
@@ -1,3 +1,0 @@
-fn main(a, b) {
-  print(a);
-}

--- a/tests/fail/0057_main_must_not_take_parameters.err
+++ b/tests/fail/0057_main_must_not_take_parameters.err
@@ -1,1 +1,0 @@
-BuildFunctionTableAndRequireMain: main function must not take parameters

--- a/tests/fail/0057_malformed_parameters.ee
+++ b/tests/fail/0057_malformed_parameters.ee
@@ -1,0 +1,3 @@
+fn main(int a, b) {
+  print(a);
+}

--- a/tests/fail/0057_malformed_parameters.err
+++ b/tests/fail/0057_malformed_parameters.err
@@ -1,0 +1,1 @@
+ParseFileContentsIntoAST: parse failed at 1:13: syntax error, unexpected 'a', expecting ')'.


### PR DESCRIPTION
## What Changed? Closes #56 
Updated VM to now be able to call any function in a EE file instead of being forced to start at main.

## Why Did You Change It?
Lua allows random functions to be called in its script files. There is no reason I see for why mine shouldn't and should force devs to start at main.

## How Did You Test It?
Passes all current tests under new architecture. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable calling any zero-argument function in an EE file by name, rather than always starting at main. The CLI still invokes main; embedders can now target any function.

- **New Features**
  - Added `VM::Call(std::string function_name)` to invoke a named function.
  - Removed the hard requirement for `main`; the interpreter builds a function table without enforcing it.
  - Updated README and tests to reflect the new calling model.

- **Migration**
  - Replace `vm.RunMain()` with `vm.Call("main")` where needed.
  - `VM::Call` currently calls zero-argument functions only; ensure the target function takes no parameters.

<sup>Written for commit 6e6043f87c01a99f98cf42d67efb94e0b20a8912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/EmreAErsahin/PL-JIT-Compiler-Project/pull/58?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

